### PR TITLE
only call __precompile__ if it's defined

### DIFF
--- a/src/Media.jl
+++ b/src/Media.jl
@@ -1,4 +1,4 @@
-__precompile__()
+isdefined(Base, :__precompile__) && __precompile__()
 
 module Media
 


### PR DESCRIPTION
should make the module loadable on 0.3
