### PR TITLE
work around `error in type inference due to #265`

### DIFF
--- a/src/system.jl
+++ b/src/system.jl
@@ -70,7 +70,7 @@ The default is `Textual`.
 media(x) = media(typeof(x))
 
 media(T, M) =
-  @eval media{T<:$T}(::Type{T}) = $M
+  @eval media{T<:$T}(::Type{T}) = $(Any[M])[1]
 
 media(Any, Media.Textual)
 


### PR DESCRIPTION
This error has been happening when trying to display almost anything non-trivial. It's due to the addition of methods to `media()` at run time, invalidating assumptions made by type inference. This change works around the problem by hiding the type of the result (so that inference doesn't assume anything).
