### PR TITLE
Denote types as code

### DIFF
--- a/src/system.jl
+++ b/src/system.jl
@@ -28,7 +28,7 @@ Similar to `abstract`:
 
     @media Foo
 
-defines Foo, as well as FooT, the type representing Foo
+defines `Foo`, as well as `FooT`, the type representing `Foo`
 and its descendants (which is useful for dispatch).
 
     @media Bar <: Foo


### PR DESCRIPTION
This makes the types show up as code in the documentation, which looks nicer and matches other docstrings.
