### PR TITLE
use 0.6.0-pre as julia lower bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 MacroTools


### PR DESCRIPTION
for `abstract type` syntax to work, shouldn't claim to support early dev versions